### PR TITLE
Major Update

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,8 +161,8 @@
                                 <span class="slider round"></span>
                             </label></div>
                         <div class="item-text-container text" id="2024rules-toggle-item">
-                            <div class="item-title">Include 2024 Rules</div>
-                            <div class="item-desc">Show/hide D&D 2024 Rules.</div>
+                            <div class="item-title">Switch to 2024 Rules</div>
+                            <div class="item-desc">Enable D&D 2024 Rules.</div>
                         </div>
                     </div>
                 </div>
@@ -196,12 +196,6 @@
         <button id="accept-cookies">Accept</button>
     </div>
     <!-- Data -->
-    <script type="text/javascript" src="js/data_movement.js" charset="utf-8"></script>
-    <script type="text/javascript" src="js/data_action.js" charset="utf-8"></script>
-    <script type="text/javascript" src="js/data_bonusaction.js" charset="utf-8"></script>
-    <script type="text/javascript" src="js/data_reaction.js" charset="utf-8"></script>
-    <script type="text/javascript" src="js/data_condition.js" charset="utf-8"></script>
-    <script type="text/javascript" src="js/data_environment.js" charset="utf-8"></script>
     <script type="text/javascript" src="js/quickref.js" charset="utf-8"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function () {
@@ -218,6 +212,21 @@
                 cookieNotice.style.display = 'none';
             });
         });
+
+        // Set default values if not present
+        if (localStorage.getItem('optional') === null) {
+            localStorage.setItem('optional', 'false');
+        }
+        if (localStorage.getItem('homebrew') === null) {
+            localStorage.setItem('homebrew', 'false');
+        }
+
+        // Set checkbox states from localStorage
+        optionalCheckbox.checked = localStorage.getItem('optional') === 'true';
+        homebrewCheckbox.checked = localStorage.getItem('homebrew') === 'true';
+
+        // Now call the function to update the UI
+        handleRulesToggle();
     </script>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -155,6 +155,16 @@
                             <div class="item-desc">Enable Darkmode</div>
                         </div>
                     </div>
+                    <div class="item itemsize" title="Include 2024 Rules">
+                        <div class="item-icon"><label class="switch">
+                                <input type="checkbox" id="rules2024-switch">
+                                <span class="slider round"></span>
+                            </label></div>
+                        <div class="item-text-container text" id="2024rules-toggle-item">
+                            <div class="item-title">Include 2024 Rules</div>
+                            <div class="item-desc">Show/hide D&D 2024 Rules.</div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -194,21 +204,21 @@
     <script type="text/javascript" src="js/data_environment.js" charset="utf-8"></script>
     <script type="text/javascript" src="js/quickref.js" charset="utf-8"></script>
     <script>
-        document.addEventListener('DOMContentLoaded', function() {
+        document.addEventListener('DOMContentLoaded', function () {
             var cookieNotice = document.getElementById('cookie-notice');
             var acceptButton = document.getElementById('accept-cookies');
-        
+
             // Check if user has already accepted cookies
             if (!localStorage.getItem('cookiesAccepted')) {
                 cookieNotice.style.display = 'block';
             }
-        
-            acceptButton.addEventListener('click', function() {
+
+            acceptButton.addEventListener('click', function () {
                 localStorage.setItem('cookiesAccepted', 'true');
                 cookieNotice.style.display = 'none';
             });
         });
-        </script>
+    </script>
 
 </body>
 

--- a/js/2024_data_action.js
+++ b/js/2024_data_action.js
@@ -1,0 +1,242 @@
+data_action = [
+    {
+        title: "Attack",
+        optional: "Standard rule",
+        icon: "crossed-swords",
+        subtitle: "Melee or ranged attack",
+        description: "Perform an attack roll with a weapon or an unarmed strike.",
+        reference: "PHB, pgs. 12, 361.",
+        bullets: [
+            "You can either equip or unequip one weapon when you make an attack as part of this action. You do so before or after the attack.",
+            "Certain features, such as the <i>Extra Attack</i> feature of the fighter, allow you to make more than one attack with this action. Each of these attacks is a separate roll and may target different creatures. You may move in between these attacks.",
+            "When you attack with a light melee weapon, you can use a bonus action to attack with another light melee weapon in your other hand (see the <i>Offhand attack</i> bonus action).",
+            "You may use an unarmed strike to <i>Grapple</i>, <i>Shove</i> or deal damage to an opponent. To deal damage, make an attack roll against the target with a bonus of your Strength Modifier plus your Proficiency Bonus and deal (1 + STR Modifier) Bludgeoning damage.",
+            "Some conditions give Advantage on the attack: attacks against blinded, paralyzed, petrified, restrained, stunned, or unconscious targets; melee attacks against prone targets; attacks by invisible or hidden attackers.",
+            "Some conditions give Disadvantage on the attack: attacks against invisible or hidden targets; ranged attacks against prone targets; attacks by blinded, frightened, poisoned, or restrained attackers."
+        ]
+    },
+    {
+        title: "Grapple",
+        optional: "Standard rule",
+        icon: "grab",
+        subtitle: "Special unarmed attack",
+        description: "Attempt to grab a creature or wrestle with it",
+        reference: "PHB, pg. 377.",
+        bullets: [
+            "You can use the <i>Attack</i> action to make a special unarmed attack, a grapple. If you're able to make multiple attacks with the Attack action, this attack replaces one of them.",
+            "The target of your grapple must be no more than one size larger than you, and you have to have a hand free to grab the target.",
+            "The target must succeed on a Strength or Dexterity saving throw (it chooses which), or it has the <i>Grappled</i> condition. The DC for the saving throw and any escape attempts is 8 + STR Modifier + Proficiency Bonus of the attacker."
+        ]
+    },
+    {
+        title: "Shove",
+        optional: "Standard rule",
+        icon: "hand",
+        subtitle: "Special unarmed attack",
+        description: "Shove a creature, either to knock it prone or push it away from you",
+        reference: "PHB, pg. 377.",
+        bullets: [
+            "You can use the <i>Attack</i> action to make a special unarmed attack, a shove. If you're able to make multiple attacks with the Attack action, this attack replaces one of them.",
+            "The target of your shove must be no more than one size larger than you.",
+            "The target must succeed on a Strength or Dexterity saving throw (it chooses which), or it will either be pushed 5 feet or knocked prone (attacker chooses which). The DC for the saving throw is 8 + STR Modifier + Proficiency Bonus of the attacker."
+        ]
+    },
+    {
+        title: "Cast a spell",
+        optional: "Standard rule",
+        icon: "magic-swirl",
+        subtitle: "Cast time of 1 action",
+        description: "Cast a spell with a casting time of 1 action",
+        reference: "PHB, pg. 235-238, 363.",
+        bullets: [
+            "On a turn, you can expend only one spell slot to cast a spell. You can't, for example, cast a spell with a spell slot as your action and another one using your bonus action on the same turn.",
+            "The target of a spell must be within the spell's range. To target something, you must have a clear path to it, so it can't be behind total cover.",
+            "Spells with material components do not consume the material unless explicitly stated. Unless the cost of a material is given, you can assume that the cost is negligible and the material is simply available in a component pouch.",
+            "Some spells require you to maintain concentration in order to keep their magic active. If you lose concentration, such a spell ends. You lose concentration on a spell if you cast another spell that requires concentration or when you are incapacitated. Each time you take damage, you must make a Constitution saving throw to maintain your concentration. The DC equals 10 or half the damage you take, whichever number is higher, up to a maximum of 30."
+        ]
+    },
+    {
+        title: "Dash",
+        optional: "Standard rule",
+        icon: "sprint",
+        subtitle: "Double movement speed",
+        description: "Gain extra movement for the current turn",
+        reference: "PHB, pg. 365.",
+        bullets: [
+            "The increase equals your speed, after applying any modifiers."
+        ]
+    },
+    {
+        title: "Disengage",
+        optional: "Standard rule",
+        icon: "journey",
+        subtitle: "Prevent opportunity attacks",
+        description: "Your movement doesn't provoke opportunity attacks for the rest of the turn",
+        reference: "PHB, pg. 366.",
+        bullets: [
+        ]
+    },
+    {
+        title: "Dodge",
+        optional: "Standard rule",
+        icon: "aura",
+        subtitle: "Increase defenses",
+        description: "Focus entirely on avoiding attacks",
+        reference: "PHB, pg. 366.",
+        bullets: [
+            "Until the start of your next turn, any attack roll made against you has Disadvantage if you can see the attacker, and you make Dexterity saving throws with Advantage.",
+            "You lose this benefit if you are <i>Incapacitated</i> or if your speed is 0."
+        ]
+    },
+    {
+        title: "Escape",
+        optional: "Standard rule",
+        icon: "manacles",
+        subtitle: "Escape a grapple",
+        description: "Escape a grapple",
+        reference: "PHB, pg. 367.",
+        bullets: [
+            "To escape a grapple, you must succeed on a Strength (Athletics) or Dexterity (Acrobatics) check against the grapple's escape DC.",
+            "Escaping other conditions that restrain you (such as manacles) may require a Dexterity or Strength check, as specified by the condition."
+        ]
+    },
+    {
+        title: "Help",
+        optional: "Standard rule",
+        icon: "telepathy",
+        subtitle: "Grant an ally advantage",
+        description: "Grant an ally advantage on an ability check or attack",
+        reference: "PHB, pg. 368.",
+        bullets: [
+            "You can choose one of your skill or tool proficiencies and one ally who is near enough for you to assist verbally or physically when they make an ability check. That ally has Advantage on the next ability check they make with the chosen skill or tool.",
+            "Alternatively, you can choose to distract an enemy within 5 feet of you, giving Advantage to the next attack roll against that enemy.",
+            "The Advantage expires, if it is not used by the start of your next turn."
+        ]
+    },
+    {
+        title: "Utilize",
+        optional: "Standard rule",
+        icon: "snatch",
+        subtitle: "Interact, use special abilities",
+        description: "Interact with an object or use special object abilities",
+        reference: "PHB, pg. 377.",
+        bullets: [
+            "You normally interact with an object while doing something else, such as when you draw a sword as part of the attack action.",
+            "When an object requires an action for its use, you take the <i>Utilize</i> action."
+        ]
+    },
+    {
+        title: "Use shield",
+        optional: "Standard rule",
+        icon: "round-shield",
+        subtitle: "Equip or unequip a shield",
+        description: "Equip or unequip a shield",
+        reference: "PHB, pgs. .",
+        bullets: [
+            "Shields require the <i>Utilize</i> action to Don or Doff.",
+            "Armor takes several minutes to equip or unequip.",
+            "You gain the Armor Class benefit of a Shield only if you have training with it."
+        ]
+    },
+    {
+        title: "Hide",
+        optional: "Standard rule",
+        icon: "hood",
+        subtitle: "Try to conceal yourself",
+        description: "Try to conceal yourself",
+        reference: "PHB, pg. 368.",
+        bullets: [
+            "You must succeed on a DC 15 Dexterity (Stealth) check while you're Heavily Obscured or behind at least Three-Quarters Cover and must be out of any enemy's line of sight.",
+            "If you can see a creature, you can discern whether it can see you.",
+            "On a successful check, you have the <i>Invisible</i> condition. Make note of your check's total, which is the DC for a creature to find you with a Wisdom (Perception) check.",
+            "The condition ends immediately after you make a sound louder than a whisper, an enemy finds you, you make an attack roll or you cast a spell with a Verbal Component."
+        ]
+    },
+    {
+        title: "Influence",
+        optional: "Standard rule",
+        icon: "magnifying-glass",
+        subtitle: "Urge a monster to do something.",
+        description: "Urge a monster to do something.",
+        reference: "PHB, pg. 369.",
+        bullets: [
+            "Describe or roleplay how you're communication with the creature. Trying to deceive, intimidate, amuse or persuade?",
+            "Your DM determines if an ability check is necessary."
+        ]
+    },
+    {
+        title: "Search",
+        optional: "Standard rule",
+        icon: "magnifying-glass",
+        subtitle: "Discern something, that isn't obvious.",
+        description: "Discern something, that isn't obvious.",
+        reference: "PHB, pg. 373.",
+        bullets: [
+            "You make a Wisdom check to discern something that isn't obvious.",
+            "E.g. Creature's state of mind = Insight, Creature's ailment or cause of death = Medicine, Concealed creature or object = Perception, Tracks or Food = Survival",
+            "Your DM may request checks using other Abilities like Intellect."
+        ]
+    },
+    {
+        title: "Study",
+        optional: "Standard rule",
+        icon: "magnifying-glass",
+        subtitle: "Study your memory, a book or a clue.",
+        description: "Study your memory, a book or a clue.",
+        reference: "PHB, pg. 375.",
+        bullets: [
+            "You make an intelligence check to study a source of knowledge and call to mind an important piece of information about it."
+        ]
+    },
+    {
+        title: "Ready",
+        optional: "Standard rule",
+        icon: "stopwatch",
+        subtitle: "Wait for a particular circumstance.",
+        description: "Choose a trigger and a response reaction",
+        reference: "PHB, pg. 372.",
+        bullets: [
+            "You take the <i>Ready</i> action on your turn, which lets you act by taking a Reaction before the start of your next turn.",
+            "Decide, what perceivable circumstance will trigger your Reaction.",
+            "Choose the action you will take in response to that trigger, or choose to move up to your Speed in response to it.",
+            "When the trigger occurs, you can either take your Reaction right after the trigger finishes or ignore the trigger.",
+            "When you ready a spell, you cast it as normal but hold its energy, which you release with your reaction when the trigger occurs. To be readied, a spell must have a casting time of 1 action, and holding onto the spell's magic requires concentration."
+        ]
+    },
+    {
+        title: "Use class feature",
+        optional: "Standard rule",
+        icon: "embrassed-energy",
+        subtitle: "Some features use actions",
+        description: "Use a racial or class feature that uses an action",
+        reference: "See class page for more information.",
+        bullets: [
+
+        ]
+    },
+    {
+        title: "Stabilize a creature",
+        optional: "Standard rule",
+        icon: "first-aid",
+        subtitle: "Stabilize a dying creature.",
+        description: "Stop a dying creature from needing to make death saving throws",
+        reference: "PHB, pg. 29.",
+        bullets: [
+            "Make a Wisdom (Medicine) check with DC 10.",
+            "On a success, the creature is stable and no longer needs to make death saving throws even though it has 0 Hit Points.",
+            "if it takes damage, it stops being stable and has to make death saving throws again.",
+            "A stable creature regains 1 hit point after 1d4 hours if it isn't healed."
+        ]
+    },
+    {
+        title: "Improvise",
+        optional: "Standard rule",
+        icon: "juggler",
+        subtitle: "Any action not on this list",
+        description: "Perform any action you can imagine",
+        reference: "PHB, pg. 15.",
+        bullets: [
+            "When you describe an action not detailed elsewhere in the rules, the DM tells you whether that action is possible and what kind of roll you need to make, if any, to determine success or failure."
+        ]
+    }
+]

--- a/js/2024_data_bonusaction.js
+++ b/js/2024_data_bonusaction.js
@@ -1,0 +1,38 @@
+data_bonusaction = [
+    {
+        title: "Offhand Attack",
+        optional: "Standard rule",
+        icon: "crossed-swords",
+        subtitle: "Use with the Attack action",
+        description: "Attack with your off hand",
+        reference: "PHB, pgs. 213.",
+        bullets: [
+            "Only usable if you take the <i>Attack</i> action and attack with a light weapon.",
+            "Perform a single attack with a different light weapon.",
+            "You don't add your ability modifier to the damage of the bonus attack, unless that modifier is negative."
+        ]
+    },
+    {
+        title: "Cast a spell",
+        optional: "Standard rule",
+        icon: "magic-swirl",
+        subtitle: "Cast time of 1 bonus action",
+        description: "Cast a spell with a casting time of 1 bonus action",
+        reference: "PHB, pgs. 235-238, 363.",
+        bullets: [
+            "On a turn, you can expend only one spell slot to cast a spell. You can't, for example, cast a spell with a spell slot as your action and another one using your bonus action on the same turn.",
+            "For further details, see the <i>Cast a spell</i> action."
+        ]
+    },
+    {
+        title: "Use class feature",
+        optional: "Standard rule",
+        icon: "embrassed-energy",
+        subtitle: "Some features use bonus actions",
+        description: "Use a racial or class feature that uses a bonus action",
+        reference: "See class page for more information.",
+        bullets: [
+
+        ]
+    }
+]

--- a/js/2024_data_condition.js
+++ b/js/2024_data_condition.js
@@ -1,0 +1,220 @@
+data_condition = [
+    {
+        title: "Blinded",
+        optional: "Standard rule",
+        icon: "one-eyed",
+        subtitle: "You can't see",
+        description: "You can't see",
+        reference: "PHB, pg. 361.",
+        bullets: [
+            "You automatically fail any ability check that requires sight.",
+            "You have Disadvantage on attack rolls.",
+            "Attack rolls against you have Advantage."
+        ]
+    },
+    {
+        title: "Charmed",
+        optional: "Standard rule",
+        icon: "smitten",
+        subtitle: "You are charmed",
+        description: "You are charmed by another creature",
+        reference: "PHB, pg. 363.",
+        bullets: [
+            "You can't attack the charmer or target them with damaging abilities or magical effects.",
+            "The charmer has Advantage on ability checks to interact with you socially."
+        ]
+    },
+    {
+        title: "Deafened",
+        optional: "Standard rule",
+        icon: "elf-ear",
+        subtitle: "You can't hear",
+        description: "You can't hear",
+        reference: "PHB, pg. 365.",
+        bullets: [
+            "You automatically fail any ability check that requires hearing."
+        ]
+    },
+    {
+        title: "Exhaustion",
+        optional: "Standard rule",
+        icon: "crawl",
+        subtitle: "You are exhausted",
+        description: "Exhaustion is measured in six levels",
+        reference: "PHB, pg. 366.",
+        bullets: [
+            "<table><tr><th>Level</th><th></th><th></th><th style='text-align:left'>D20 Tests</th><th></th><th></th><th>Speed</th></tr><tr><td>1</td><td></td><td></td><td>-2</td><td></td><td></td><td>-5 ft.</td></tr><tr><td>2</td><td></td><td></td><td>-4</td><td></td><td></td><td>-10 ft.</td></tr><tr><td>3</td><td></td><td></td><td>-6</td><td></td><td></td><td>-15 ft.</td></tr><tr><td>4</td><td></td><td></td><td>-8</td><td></td><td></td><td>-20 ft.</td></tr><tr><td>5</td><td></td><td></td><td>-10</td><td></td><td></td><td>-25 ft.</td></tr><tr><td>6</td><td></td><td></td><td>Death</td><td></td><td></td><td>Death</td></tr></table>",
+            "This condition is cumulative. Each time you receive it, you gain 1 Exhaustion level. You die if your Exhaustion level is 6.",
+            "Finishing a long rest reduces your exhaustion level by 1. When your Exhaustion level reaches 0, the condition ends."
+        ]
+    },
+    {
+        title: "Frightened",
+        optional: "Standard rule",
+        icon: "sharp-smile",
+        subtitle: "You are frightened",
+        description: "You are frightened",
+        reference: "PHB, pg. 367.",
+        bullets: [
+            "You have Disadvantage on ability checks and attack rolls while the source of fear is within line of sight.",
+            "You can't willingly move closer to the source of fear."
+        ]
+    },
+    {
+        title: "Grappled",
+        optional: "Standard rule",
+        icon: "grab",
+        subtitle: "You are grappled",
+        description: "You are grappled",
+        reference: "PHB, pg. 367.",
+        bullets: [
+            "Your speed is 0 and can't increase.",
+            "You have Disadvantage on attack rolls against any target other than the grappler.",
+            "The grappler can drag or carry you when it moves, but every foot of movement costs 1 extra foot unless you are Tiny or 2 or more sizes smaller."
+        ]
+    },
+    {
+        title: "Incapacitated",
+        optional: "Standard rule",
+        icon: "internal-injury",
+        subtitle: "You can't take actions or reactions",
+        description: "You can't take actions or reactions",
+        reference: "PHB, pg. 369.",
+        bullets: [
+            "Your Concentration is broken.",
+            "You can't speak.",
+            "You have Disadvantage on Initiative rolls."
+        ]
+    },
+    {
+        title: "Invisible",
+        optional: "Standard rule",
+        icon: "invisible",
+        subtitle: "You can't be seen",
+        description: "You can't be seen without the aid of magic or a special sense",
+        reference: "PHB, pg. 370.",
+        bullets: [
+            "You have Advantage on Initiative rolls and attack rolls unless your target can somehow see you.",
+            "Attack rolls against you have Disadvantage, unless your attacker can somehow see you",
+            "You aren't affected by any effect that requires its target to be seen unless the effect's creator can somehow see you. Any equipment you are wearing or carrying is also concealed."
+        ]
+    },
+    {
+        title: "Paralyzed",
+        optional: "Standard rule",
+        icon: "internal-injury",
+        subtitle: "You are paralyzed",
+        description: "You can't do anything",
+        reference: "PHB, pg. 371.",
+        bullets: [
+            "You have the Incapacitated condition.",
+            "Your speed is 0 and can't increase.",
+            "Attack rolls against you have Advantage and any attack that hits you is a critical hit if the attacker is within 5 feet of you.",
+            "You automatically fail Strength and Dexterity saving throws."
+        ]
+    },
+    {
+        title: "Petrified",
+        optional: "Standard rule",
+        icon: "stone-pile",
+        subtitle: "You are transformed into stone",
+        description: "You are transformed, along with any nonmagical objects you are wearing or carrying, into a solid inanimate substance (usually stone)",
+        reference: "PHB, pg. 372.",
+        bullets: [
+            "Your weight increases by a factor of ten, and you cease aging.",
+            "You have the Incapacitated condition.",
+            "Your speed is 0 and can't increase.",
+            "Attack rolls against you have Advantage.",
+            "You automatically fail Strength and Dexterity saving throws.",
+            "You have resistance to all damage.",
+            "You have Immunity to the Poisoned condition."
+        ]
+    },
+    {
+        title: "Poisoned",
+        optional: "Standard rule",
+        icon: "deathcab",
+        subtitle: "You are poisoned",
+        description: "You are poisoned",
+        reference: "PHB, pg. 372.",
+        bullets: [
+            "You have Disadvantage on attack rolls and ability checks."
+        ]
+    },
+    {
+        title: "Prone",
+        optional: "Standard rule",
+        icon: "crawl",
+        subtitle: "You are prone",
+        description: "You are prone",
+        reference: "PHB, pg. 372.",
+        bullets: [
+            "Your only movement option is to crawl, unless you stand up. If your speed is 0, you can't stand up.",
+            "You have Disadvantage on attack rolls.",
+            "Attack rolls against you have Advantage if the attacker is within 5 feet of you, otherwise the attack roll has Disadvantage."
+        ]
+    },
+    {
+        title: "Restrained",
+        optional: "Standard rule",
+        icon: "imprisoned",
+        subtitle: "You are restrained",
+        description: "You are restrained",
+        reference: "PHB, pg. 373.",
+        bullets: [
+            "Your speed is 0 and can't increase.",
+            "You have Disadvantage on attack rolls.",
+            "Attack rolls against you have Advantage.",
+            "You have Disadvantage on Dexterity saving throws."
+        ]
+    },
+    {
+        title: "Stunned",
+        optional: "Standard rule",
+        icon: "internal-injury",
+        subtitle: "You are stunned",
+        description: "You are stunned",
+        reference: "PHB, pg. 376.",
+        bullets: [
+            "You have the Incapacitated condition.",
+            "Attack rolls against you have Advantage.",
+            "You automatically fail Strength and Dexterity saving throws."
+        ]
+    },
+    {
+        title: "Unconscious",
+        optional: "Standard rule",
+        icon: "coma",
+        subtitle: "You are unconscious",
+        description: "You are unconscious",
+        reference: "PHB, pg. 377.",
+        bullets: [
+            "You have the Incapacitated and Prone conditions and you drop whatever you're holding.",
+            "Your speed is 0 and can't increase.",
+            "Attack rolls against you have Advantage.",
+            "Any attack that hits you is a critical hit if the attacker is within 5 feet of you.",
+            "You automatically fail Strength and Dexterity saving throws.",
+        ]
+    },
+    {
+        title: "Dying",
+        optional: "Standard rule",
+        icon: "dead-head",
+        subtitle: "You are dying",
+        description: "You have been dropped to zero hit points and are dying",
+        reference: "PHB, pg. 197.",
+        bullets: [
+            "If you are reduced to 0 hit points by damage that fails to kill you, you fall unconscious and are dying.",
+            "If you receive any healing you immediately regain consciousness and are no longer dying.",
+            "When you start your turn with 0 hit points, you must make a Death Saving Throw without modifiers.",
+            "10 or higher is a success, 9 or lower is a failure.",
+            "On your third success, you become stable.",
+            "On your third failure, you die.",
+            "Rolling a 1 counts as two failures.",
+            "Rolling a 20 immediately causes you to regain 1 hit point.",
+            "If you take damage while dying, you suffer a failure. If it's from a critical hit, you suffer 2 failures.",
+            "You can be stabilized by an ally taking the Help (Stabilize) action and succeeding on a DC 10 Wisdom (Medicine) check.",
+            "Once stable, you are at 0 HP, still unconcious, but no longer dying. you regain 1 hit point after 1d4 hours if not healed."
+        ]
+    }
+]

--- a/js/2024_data_environment.js
+++ b/js/2024_data_environment.js
@@ -1,0 +1,162 @@
+data_environment_obscurance = [
+    {
+        title: "Lightly obscured",
+        optional: "Standard rule",
+        icon: "bleeding-eye",
+        subtitle: "Disadvantage on Perception",
+        description: "Dim light, patchy fog, moderate foliage.",
+        reference: "PHB, pg. 19.",
+        bullets: [
+            "Creatures have <b>Disadvantage on Wisdom (Perception)</b> checks that rely on sight."
+        ]
+    },
+    {
+        title: "Heavily obscured",
+        optional: "Standard rule",
+        icon: "lightning-tear",
+        subtitle: "Effectively blind",
+        description: "Darkness, opaque fog, dense foliage",
+        reference: "PHB, pg. 19.",
+        bullets: [
+            "Creatures have the <b>Blinded</b> condition, when trying to see something."
+        ]
+    }
+]
+
+data_environment_light = [
+    {
+        title: "Bright light",
+        optional: "Standard rule",
+        icon: "star-pupil",
+        subtitle: "Normal vision",
+        description: "Bright light lets most creatures see normally",
+        reference: "PHB, pg. 19.",
+        bullets: [
+            "Gloomy days still provide bright light, as do torches, lanterns, fires, and other sources of illumination within a specific radius."
+        ]
+    },
+    {
+        title: "Dim light",
+        optional: "Standard rule",
+        icon: "semi-closed-eye",
+        optional: "Standard rule",
+        subtitle: "Lightly obscured",
+        description: "Dim light, also called shadows",
+        reference: "PHB, pg. 19.",
+        bullets: [
+            "Creates a <b>lightly obscured</b> area.",
+            "An area of dim light is usually a boundary between a source of bright light, such as a torch, and surrounding darkness.",
+            "The soft light of twilight and dawn also counts as dim light. A particularly brilliant full moon might bathe the land in dim light."
+        ]
+    },
+    {
+        title: "Darkness",
+        optional: "Standard rule",
+        optional: "Standard rule",
+        icon: "worried-eyes",
+        subtitle: "Heavily obscured",
+        description: "Darkness creates a heavily obscured area",
+        reference: "PHB, pg. 19.",
+        bullets: [
+            "Creates a <b>heavily obscured</b> area.",
+            "Characters face darkness outdoors at night (even most moonlit nights), within the confines of an unlit dungeon or a subterranean vault, or in an area of magical darkness."
+        ]
+    }
+]
+
+data_environment_vision = [
+    {
+        title: "Blindsight",
+        optional: "Standard rule",
+        icon: "one-eyed",
+        subtitle: "Perceive without sight",
+        description: "You can see within a specified range without relying on physical sight.",
+        reference: "PHB, pg. 361.",
+        bullets: [
+            "You can see anything that isn't behind Total Cover even if you have the Blinded condition or are in Darkness.",
+            "You can see something that has the Invisible condition.",
+            "Creatures without eyes, such as oozes, and creatures with echolocation or heightened senses, such as bats and true dragons, have this sense."
+        ]
+    },
+    {
+        title: "Darkvision",
+        optional: "Standard rule",
+        icon: "semi-closed-eye",
+        subtitle: "Limited vision in darkness",
+        description: "A creature with Darkvision can see better in the dark or low light conditions, within a certain radius",
+        reference: "PHB, pg. 365",
+        bullets: [
+            "Within a specified range, a creature with darkvision can see in Dim Light as if it were Bright Light and in Darkness as if it were Dim Light.",
+            "However, the creature can’t discern color in darkness, only shades of gray.",
+            "Many creatures in the worlds of D&D, especially those that dwell underground, have darkvision."
+        ]
+    },
+    {
+        title: "Tremorsense",
+        optional: "Standard rule",
+        icon: "semi-closed-eye",
+        subtitle: "Sense vibrations",
+        description: "pinpoint location of creatures in contact with the same surfaces you are",
+        reference: "PHB, pg. 377.",
+        bullets: [
+            "Within a specified range, a creature with Tremorsense can pinpoint the location of creatures and moving objects, provided that the creature with Tremorsense and anything it is detecting are both in contact with the same surface or liquid.",
+            "Tremorsense can't detect creatures in the air, and it doesn't count as a form of sight."
+        ]
+    },
+    {
+        title: "Truesight",
+        optional: "Standard rule",
+        icon: "eye-shield",
+        subtitle: "See in darkness",
+        description: "Your vision is enhanced within a specified range, it pierces the following",
+        reference: "PHB, pg. 377.",
+        bullets: [
+            "You can see in normal and magical Darkness.",
+            "You can see creatures and objects that have the Invisible condition.",
+            "Visual illusions appear transparent to you, and you automatically succeed on saving throws against them.",
+            "You discern the true form of any creature or object you see that has been transformed by magic.",
+            "You see into the Ethereal Plane."
+        ]
+    }
+]
+
+data_environment_cover = [
+    {
+        title: "Half cover",
+        optional: "Standard rule",
+        icon: "broken-shield",
+        subtitle: "Low wall, furniture, creatures",
+        description: "A target has half cover if an obstacle blocks at least half of its body",
+        reference: "PHB, pg. 25-26.",
+        bullets: [
+            "The obstacle might be a low wall, a large piece of furniture, a narrow tree trunk, or a creature, whether that creature is an enemy or a friend.",
+            "A target with half cover has a <b>+2 bonus to AC and Dexterity saving throws</b>.",
+            "If a target is behind multiple sources of cover, only the most protective degree of cover applies"
+        ]
+    },
+    {
+        title: "Three-quarters cover",
+        optional: "Standard rule",
+        icon: "cracked-shield",
+        subtitle: "Portcullis, arrow slit",
+        description: "A target has three-quarters cover if about three-quarters of it is covered by an obstacle",
+        reference: "PHB, pg. 25-26.",
+        bullets: [
+            "The obstacle might be a portcullis, an arrow slit, or a thick tree trunk.",
+            "A target with three-quarters cover has a <b>+5 bonus to AC and Dexterity saving throws</b>.",
+            "If a target is behind multiple sources of cover, only the most protective degree of cover applies"
+        ]
+    },
+    {
+        title: "Full cover",
+        optional: "Standard rule",
+        icon: "shield",
+        subtitle: "Completely concealed",
+        description: "A target has total cover if it is completely concealed by an obstacle",
+        reference: "PHB, pg. 25-26.",
+        bullets: [
+            "A target with total cover <b>can’t be targeted directly</b> by an attack or a spell, although some spells can reach such a target by including it in an area of effect.",
+            "If a target is behind multiple sources of cover, only the most protective degree of cover applies"
+        ]
+    }
+]

--- a/js/2024_data_movement.js
+++ b/js/2024_data_movement.js
@@ -1,0 +1,165 @@
+data_movement = [
+    {
+        title: "Move",
+        optional: "Standard rule",
+        icon: "run",
+        subtitle: "Cost: 5ft per 5ft",
+        description: "Movement cost: 5ft per 5ft moved",
+        reference: "PHB, pg. 24-25, 374.",
+        bullets: [
+            "If you have more than one speed, such as your walking speed and a flying speed, you can switch back and forth between your speeds during your move. Whenever you switch, subtract the distance you've already moved from the new speed.",
+            "You can move through the space of an ally, a creature that has the <i>Incapacitated</i> condition, a Tiny creature or a creature that is two sizes larger or smaller than you.",
+            "Another creature's space is difficult terrain for you unless that creature is Tiny or your ally.",
+            "You can't willingly end your move in a space occupied by another creature. If you somehow end a turn in a space with another creature, you have the <i>Prone</i> condition, unless you are Tiny or are of a larger size than the other creature."
+        ]
+    },
+    {
+        title: "Climb",
+        optional: "Standard rule",
+        icon: "crags",
+        subtitle: "Cost: +5ft per 5ft",
+        description: "Movement cost: each foot of movement costs 1 extra foot",
+        reference: "PHB, pg. 363.",
+        bullets: [
+            "Each foot of movement costs 1 extra foot of movement while climbing. If you have a climb speed, you ignore this extra cost.",
+            "May involve a Strength (Athletics) check if the climb is difficult."
+        ]
+    },
+    {
+        title: "Swim",
+        optional: "Standard rule",
+        icon: "at-sea",
+        subtitle: "Cost: +5ft per 5ft",
+        description: "Movement cost: each foot of movement costs 1 extra foot",
+        reference: "PHB, pg. 376.",
+        bullets: [
+            "Each foot of movement costs 1 extra foot of movement while swimming. If you have a swim speed, you ignore this extra cost.",
+            "May involve a Strength (Athletics) check if you're swimming in rough waters."
+        ]
+    },
+    {
+        title: "Flying",
+        optional: "Standard rule",
+        icon: "angel-wings",
+        subtitle: "Cost: 5ft per 5ft",
+        description: "Movement cost: 5ft per 5ft flown",
+        reference: "PHB, pg. 367.",
+        bullets: [
+            "While you have a fly speed, you can stay aloft until you land, fall or die.",
+            "While flying, you fall if you have the <i>Incapacitated</i> or <i>Prone</i> condition or your fly speed is reduced to 0.",
+            "You can stay aloft in those circumstances if you can hover."
+        ]
+    },
+    {
+        title: "Drop prone",
+        optional: "Standard rule",
+        icon: "falling",
+        subtitle: "Cost: 0ft",
+        description: "Movement cost: 0ft (free)",
+        reference: "PHB, pgs. 25, 372.",
+        bullets: [
+            "You can drop prone without using any of your speed.",
+            "To move while prone, you must crawl or use magic such as teleportation",
+            "Dropping prone adds the <i>Prone</i> condition."
+        ]
+    },
+    {
+        title: "Crawl",
+        optional: "Standard rule",
+        icon: "crawl",
+        subtitle: "Cost: +5ft per 5ft",
+        description: "Movement cost: each foot of movement costs 1 extra foot",
+        reference: "PHB, pg. 364.",
+        bullets: [
+            "Each foot of movement costs 1 extra foot of movement while crawling."
+        ]
+    },
+    {
+        title: "Stand up",
+        optional: "Standard rule",
+        icon: "strong",
+        subtitle: "Cost: half movement speed",
+        description: "Movement cost: half of your speed, rounded down.",
+        reference: "PHB, pg. 372.",
+        bullets: [
+            "You can't stand up if you don't have enough movement left or if your speed is 0"
+        ]
+    },
+    {
+        title: "High jump",
+        optional: "Standard rule",
+        icon: "wingfoot",
+        subtitle: "Cost: 5ft",
+        description: "Movement cost: 5ft per 5ft jumped",
+        reference: "PHB, pg. 368.",
+        bullets: [
+            "You leap into the air a number of feet equal to <b>3 + your Strength modifier</b> if you move at least 10 feet on foot immediately before the jump.",
+            "When you make a standing high jump, you can jump only half that distance.",
+            "You can extend your arms half your height above yourself during the jump. Thus, you can reach a distance equal to the height of the jump plus 1.5 times your height.",
+            "In some circumstances, your DM might allow you to make a Strength (Athletics) check to jump higher than you normally can."
+        ]
+    },
+    {
+        title: "Long jump",
+        optional: "Standard rule",
+        icon: "wingfoot",
+        subtitle: "Cost: 5ft per 5ft",
+        description: "Movement cost: 5ft per 5ft jumped",
+        reference: "PHB, pg. 370.",
+        bullets: [
+            "You cover a number of feet up to your <b>Strength score</b> if you move at least 10 feet on foot immediately before the jump.",
+            "When you make a standing long jump, you can leap only half that distance",
+            "If you land in difficult terrain, you must succeed on a DC 10 Dexterity (Acrobatics) check or have the <i>Prone</i> condition.",
+            "May involve a DC 10 Strength (Athletics) check to clear a low obstacle (no taller than a quarter of the jump's distance). You hit the obstacle on a failed check."
+        ]
+    },
+    {
+        title: "Improvise",
+        optional: "Standard rule",
+        icon: "juggler",
+        subtitle: "Any stunt not on this list",
+        description: "Perform any movement or stunt you can imagine",
+        bullets: [
+            "When you describe a kind of movement not detailed elsewhere in the rules, the DM tells you whether it is possible and what kind of roll you need to make, if any, to determine success or failure."
+        ]
+    },
+    {
+        title: "Difficult terrain",
+        optional: "Standard rule",
+        icon: "stone-pile",
+        subtitle: "Cost modifier: +5ft per 5ft",
+        reference: "PHB, pg. 25, 366.",
+        description: "Moving in difficult terrain costs an additional 5ft per 5ft of movement",
+        bullets: [
+            "Every foot of movement costs 1 extra foot.",
+            "Difficult terrain isn't cumulative; either a space is difficult terrain or it isn't."
+        ]
+    },
+    {
+        title: "Grapple move",
+        optional: "Standard rule",
+        icon: "grab",
+        subtitle: "Cost: +5ft per 5ft",
+        description: "Drag or carry the grappled creature with you",
+        reference: "PHB, pg. 367.",
+        bullets: [
+            "If you move while grappling another creature, every foot of movement costs 1 extra foot unless the grappled creature is Tiny or you are two or more sizes larger than it."
+        ]
+    },
+    {
+        title: "Travel Pace",
+        optional: "Standard rule",
+        icon: "run",
+        subtitle: "Traveling outside of combat",
+        description: "Travel Pace for Fast, Normal and Slow Travel outside of combat.",
+        reference: "PHB, pg. 20",
+        bullets: [
+            "Establish a marching order while you travel.",
+            "<table><tr><th style='text-align:left'>Pace</th><th></th><th></th><th>Minute</th><th></th><th></th><th>Hour</th><th></th><th></th><th>Day</th></tr><tr><td>Fast</td><td></td><td></td><td>400 feet</td><td></td><td></td><td>4 miles</td><td></td><td></td><td>30 miles</td></tr><tr><td>Normal</td><td></td><td></td><td>300 feet</td><td></td><td></td><td>3 miles</td><td></td><td></td><td>24 miles</td></tr><tr><td>Slow</td><td></td><td></td><td>200 feet</td><td></td><td></td><td>2 miles</td><td></td><td></td><td>18 miles</td></tr></table>",
+            "<b>Fast Travel</b> imposes Disadvantage on a traveler's Wisdom (Perception or Survival) and Dexterity (Stealth) checks.",
+            "<b>Normal Travel</b> imposes Disadvantage on Dexterity (Stealth) checks.",
+            "<b>Slow Travel</b> grants Advantage on Wisdom (Perception or Survival) checks.",
+            "Travelers in wagons, carriages or other land vehicles choose a pace as normal. Characters in a waterborne vessel are limited to the speed of the vessel and don't choose a pace."
+        ]
+    }
+]

--- a/js/2024_data_reaction.js
+++ b/js/2024_data_reaction.js
@@ -1,0 +1,38 @@
+data_reaction = [
+    {
+        title: "Opportunity attack",
+        optional: "Standard rule",
+        icon: "crossed-swords",
+        subtitle: "Enemy leaves your reach",
+        description: "You can rarely move heedlessly past your foes without putting yourself in danger",
+        reference: "PHB, pg. 371.",
+        bullets: [
+            "Trigger: enemy creature you can see leaves your reach using its action, its Bonus Action, its Reaction or one of its Speeds.",
+            "Make one melee attack with a weapon or an unarmed strike against the provoking creature.",
+            "The attack occurs right before the creature leaves your reach."
+        ]
+    },
+    {
+        title: "Readied action",
+        optional: "Standard rule",
+        icon: "stopwatch",
+        subtitle: "Part of your Ready action",
+        description: "Execute the reaction specified by your Ready action",
+        reference: "PHB, pg. 372-373.",
+        bullets: [
+            "Trigger and Reaction: specified by your <i>Ready</i> action."
+        ]
+    },
+    {
+        title: "Cast a spell",
+        optional: "Standard rule",
+        icon: "magic-swirl",
+        subtitle: "Cast time of 1 reaction",
+        description: "Cast a spell with a casting time of 1 reaction",
+        reference: "PHB, pg. 235-238.",
+        bullets: [
+            "Trigger: specified by the spell.",
+            "For further details, see the <i>Cast a spell</i> action."
+        ]
+    }
+]

--- a/js/quickref.js
+++ b/js/quickref.js
@@ -129,6 +129,7 @@ document.addEventListener("DOMContentLoaded", function () {
     var optionalCheckbox = document.getElementById('optional-switch');
     var homebrewCheckbox = document.getElementById('homebrew-switch');
     var darkModeCheckbox = document.getElementById('darkmode-switch');
+    var rules2024Checkbox = document.getElementById('rules2024-switch');
 
     // Function to handle checkbox changes for optional and homebrew rules
     function handleRulesToggle() {
@@ -164,19 +165,29 @@ document.addEventListener("DOMContentLoaded", function () {
         });
     }
 
+    // Function to handle 2024 rules toggle
+    function handle2024RulesToggle() {
+        // Store the value in localStorage
+        localStorage.setItem('rules2024', rules2024Checkbox.checked ? 'true' : 'false');
+        // Reload the page to load the correct data files
+        location.reload();
+    }
+
     // Add event listeners to the checkboxes
     optionalCheckbox.addEventListener('change', handleRulesToggle);
     homebrewCheckbox.addEventListener('change', handleRulesToggle);
     darkModeCheckbox.addEventListener('change', handleDarkModeToggle);
+    rules2024Checkbox.addEventListener('change', handle2024RulesToggle);
 
     // Call the functions to initially set the correct states
     handleRulesToggle();
-    handleDarkModeToggle(); // This will now apply the correct initial state
+    handleDarkModeToggle();
 
     // Get the toggle items
     var optionalToggleItem = document.getElementById('optional-toggle-item');
     var homebrewToggleItem = document.getElementById('homebrew-toggle-item');
     var darkModeToggleItem = document.getElementById('darkmode-toggle-item');
+    var rules2024ToggleItem = document.getElementById('2024rules-toggle-item');
 
     // Function to handle click on the toggle items
     function handleToggleClick(checkbox) {
@@ -190,8 +201,43 @@ document.addEventListener("DOMContentLoaded", function () {
     optionalToggleItem.addEventListener('click', handleToggleClick(optionalCheckbox));
     homebrewToggleItem.addEventListener('click', handleToggleClick(homebrewCheckbox));
     darkModeToggleItem.addEventListener('click', handleToggleClick(darkModeCheckbox));
+    rules2024ToggleItem.addEventListener('click', handleToggleClick(rules2024Checkbox));
 
     // Ensure dark mode is off by default
     darkModeCheckbox.checked = false;
     handleDarkModeToggle();
+
+    // Set 2024 rules toggle state from localStorage
+    var rules2024 = localStorage.getItem('rules2024') === 'true';
+    rules2024Checkbox.checked = rules2024;
 });
+
+// Dynamically load the correct data files based on the 2024 rules toggle
+(function() {
+    var rules2024 = localStorage.getItem('rules2024') === 'true';
+    var head = document.getElementsByTagName('head')[0];
+
+    function loadScript(src) {
+        var script = document.createElement('script');
+        script.src = src;
+        script.defer = false;
+        head.appendChild(script);
+    }
+
+    // Always load movement and other non-action files as usual
+    loadScript('js/data_movement.js');
+    loadScript('js/data_bonusaction.js');
+    loadScript('js/data_reaction.js');
+    loadScript('js/data_condition.js');
+    loadScript('js/data_environment_obscurance.js');
+    loadScript('js/data_environment_light.js');
+    loadScript('js/data_environment_vision.js');
+    loadScript('js/data_environment_cover.js');
+
+    // Load the correct action file
+    if (rules2024) {
+        loadScript('js/2024_data_action.js');
+    } else {
+        loadScript('js/data_action.js');
+    }
+})();

--- a/js/quickref.js
+++ b/js/quickref.js
@@ -1,64 +1,92 @@
+// Loads the appropriate rule data files based on the 2024 rules toggle
+(function() {
+    var rules2024 = localStorage.getItem('rules2024') === 'true';
+    var head = document.getElementsByTagName('head')[0];
+
+    function loadScript(src) {
+        var script = document.createElement('script');
+        script.src = src;
+        script.defer = false;
+        head.appendChild(script);
+    }
+
+    function loadRuleFile(base) {
+        if (rules2024) {
+            loadScript('js/2024_' + base + '.js');
+        } else {
+            loadScript('js/' + base + '.js');
+        }
+    }
+
+    var ruleFiles = [
+        'data_movement',
+        'data_action',
+        'data_bonusaction',
+        'data_reaction',
+        'data_condition',
+        'data_environment',
+    ];
+
+    ruleFiles.forEach(loadRuleFile);
+})();
+
+// Adds a quick reference item to the parent element and sets up modal open logic with section color
 function add_quickref_item(parent, data, type) {
-    // Set default values for icon, subtitle, and title if not provided in the data object
     var icon = data.icon || "perspective-dice-six-faces-one";
     var subtitle = data.subtitle || "";
     var title = data.title || "[no title]";
-    var optional = data.optional || "false"; // Get the optional property from the data object
-    // Create a new 'div' element for the quick reference item
+    var optional = data.optional || "Standard rule";
     var item = document.createElement("div");
-    // Add classes to the item element
     item.className = "item itemsize";
 
-    // Create the item-icon element
     var itemIcon = document.createElement("div");
     itemIcon.className = "item-icon iconsize icon-" + icon;
     item.appendChild(itemIcon);
 
-    // Create the item-text-container element
     var itemTextContainer = document.createElement("div");
     itemTextContainer.className = "item-text-container text";
 
-    // Create the item-title element
     var itemTitle = document.createElement("div");
     itemTitle.className = "item-title";
     itemTitle.textContent = title;
     itemTextContainer.appendChild(itemTitle);
 
-    // Create the item-desc element
     var itemDesc = document.createElement("div");
     itemDesc.className = "item-desc";
     itemDesc.textContent = subtitle;
     itemTextContainer.appendChild(itemDesc);
 
-    // Append the item-text-container to the item element
     item.appendChild(itemTextContainer);
 
-    // Get the background color of the parent's parent's parent element
-    var style = window.getComputedStyle(parent.parentNode.parentNode);
-    var color = style.backgroundColor;
-
-    // Attach a click event to the item, which triggers the show_modal function with data, color, and type parameters
+    // Set up click event to open the modal with section and title colors
     item.onclick = function () {
-        show_modal(data, color, type);
+        // Always get the latest colors and dark mode state
+        var section = parent.parentNode.parentNode;
+        var style = window.getComputedStyle(section);
+        var color = style.backgroundColor;
+        var borderColor = style.borderColor;
+        var darkMode = document.body.classList.contains('dark-mode-active') || document.querySelector('.dark-mode')?.classList.contains('dark-mode-active');
+
+        // Get the section title color for the modal title
+        var sectionTitle = section.querySelector('.section-title');
+        var titleColor = sectionTitle ? window.getComputedStyle(sectionTitle).color : style.color;
+
+        show_modal(data, color, type, titleColor, borderColor, darkMode);
     }
-    // Set the title attribute of the item div to the value of the optional property
     item.setAttribute("title", optional);
-    // Append the created item to the specified parent element
     parent.appendChild(item);
 }
 
-function show_modal(data, color, type) {
+// Displays the modal with the provided data and section colors
+function show_modal(data, color, type, titleColor, borderColor, darkMode) {
     var title = data.title || "[no title]";
     var subtitle = data.description || data.subtitle || "";
     var bullets = data.bullets || [];
     var reference = data.reference || "";
     type = type || "";
-    color = color || "black";
 
-    // Add a class to the body to simulate $("body").addClass("modal-open");
     document.body.classList.add("modal-open");
 
-    // Get references to the modal and its elements using document.getElementById
     var modal = document.getElementById("modal");
     var modalBackdrop = document.getElementById("modal-backdrop");
     var modalContainer = document.getElementById("modal-container");
@@ -67,38 +95,39 @@ function show_modal(data, color, type) {
     var modalReference = document.getElementById("modal-reference");
     var modalBullets = document.getElementById("modal-bullets");
 
-    // Set styles and content using standard DOM properties
     modal.classList.add("modal-visible");
     modalBackdrop.style.height = window.innerHeight + "px";
+
+    // Apply section colors to modal
     modalContainer.style.backgroundColor = color;
-    modalContainer.style.borderColor = color;
+    modalContainer.style.borderColor = borderColor || color;
+    modalTitle.style.color = titleColor || '';
+
     modalTitle.innerHTML = title + "<span class=\"float-right\">" + type + "</span>";
     modalSubtitle.textContent = subtitle;
     modalReference.textContent = reference;
 
-    // Create HTML for bullets using map and join
     var bulletsHTML = bullets.map(function (item) {
         return "<p class=\"fonstsize\">" + item + "</p>";
     }).join("\n<hr>\n");
 
-    // Set the innerHTML of modalBullets
     modalBullets.innerHTML = bulletsHTML;
 }
 
+// Hides the modal if the click is outside the modal container
 function hide_modal(event) {
     var modalContainer = document.getElementById("modal-container");
-
-    // Check if the clicked element is outside of the modal container
     if (!modalContainer.contains(event.target)) {
         document.body.classList.remove("modal-open");
         document.getElementById("modal").classList.remove("modal-visible");
     }
 }
 
-// Update the click event handling for the modal
+// Add click event to modal for hiding
 var modal = document.getElementById("modal");
 modal.addEventListener("click", hide_modal);
 
+// Fills a section with quick reference items from data
 function fill_section(data, parentname, type) {
     var parent = document.getElementById(parentname);
     data.forEach(function (item) {
@@ -106,6 +135,7 @@ function fill_section(data, parentname, type) {
     });
 }
 
+// Initializes all quick reference sections and modal event
 function init() {
     fill_section(data_movement, "basic-movement", "Move");
     fill_section(data_action, "basic-actions", "Action");
@@ -121,29 +151,67 @@ function init() {
     modal.addEventListener("click", hide_modal);
 }
 
-document.addEventListener("DOMContentLoaded", init);
+window.onload = function() {
+    init();
+    // Update item visibility after items are created
+    handleRulesToggle();
+}
 
-//Settings Switches
+// Handles settings switches and toggles for rules, dark mode, and homebrew
+// Sets up event listeners and initial states
+// Applies visibility and mode changes to items and page
+
 document.addEventListener("DOMContentLoaded", function () {
-    // Select the checkboxes
+    if (localStorage.getItem('optional') === null) {
+        localStorage.setItem('optional', 'false');
+    }
+    if (localStorage.getItem('homebrew') === null) {
+        localStorage.setItem('homebrew', 'false');
+    }
+
     var optionalCheckbox = document.getElementById('optional-switch');
     var homebrewCheckbox = document.getElementById('homebrew-switch');
     var darkModeCheckbox = document.getElementById('darkmode-switch');
     var rules2024Checkbox = document.getElementById('rules2024-switch');
 
-    // Function to handle checkbox changes for optional and homebrew rules
-    function handleRulesToggle() {
-        console.log("Rules switches toggled"); // Debugging statement
-        var items = document.getElementsByClassName('item itemsize');
+    var rules2024 = localStorage.getItem('rules2024') === 'true';
+    rules2024Checkbox.checked = rules2024;
 
+    var darkmode = localStorage.getItem('darkmode') === 'true';
+    darkModeCheckbox.checked = darkmode;
+
+    var optional = localStorage.getItem('optional') === 'true';
+    optionalCheckbox.checked = optional;
+
+    var homebrew = localStorage.getItem('homebrew') === 'true';
+    homebrewCheckbox.checked = homebrew;
+
+    handleDarkModeToggle();
+
+    optionalCheckbox.addEventListener('change', function() {
+        localStorage.setItem('optional', optionalCheckbox.checked ? 'true' : 'false');
+        handleRulesToggle();
+    });
+    homebrewCheckbox.addEventListener('change', function() {
+        localStorage.setItem('homebrew', homebrewCheckbox.checked ? 'true' : 'false');
+        handleRulesToggle();
+    });
+    darkModeCheckbox.addEventListener('change', function() {
+        localStorage.setItem('darkmode', darkModeCheckbox.checked ? 'true' : 'false');
+        handleDarkModeToggle();
+    });
+    rules2024Checkbox.addEventListener('change', handle2024RulesToggle);
+
+    // Updates item visibility based on optional and homebrew toggles
+    function handleRulesToggle() {
+        var items = document.getElementsByClassName('item itemsize');
         for (var i = 0; i < items.length; i++) {
             var item = items[i];
-            var itemType = item.getAttribute('title');
-            var isOptional = itemType === 'Optional rule';
-            var isHomebrew = itemType === 'Homebrew rule';
-
-            if ((optionalCheckbox.checked && isOptional) ||
-                (homebrewCheckbox.checked && isHomebrew) ||
+            var ruleType = item.getAttribute('title');
+            var isOptional = ruleType === 'Optional rule';
+            var isHomebrew = ruleType === 'Homebrew rule';
+            if ((isOptional && optionalCheckbox.checked) ||
+                (isHomebrew && homebrewCheckbox.checked) ||
                 (!isOptional && !isHomebrew)) {
                 item.style.display = 'block';
             } else {
@@ -152,9 +220,8 @@ document.addEventListener("DOMContentLoaded", function () {
         }
     }
 
-    // Function to handle darkmode toggle
+    // Applies or removes dark mode classes and stores state
     function handleDarkModeToggle() {
-        console.log("Dark mode switch toggled"); // Debugging statement
         const darkModeElements = document.querySelectorAll('.dark-mode, .page-background');
         darkModeElements.forEach(element => {
             if (darkModeCheckbox.checked) {
@@ -163,33 +230,23 @@ document.addEventListener("DOMContentLoaded", function () {
                 element.classList.remove('dark-mode-active');
             }
         });
+        localStorage.setItem('darkmode', darkModeCheckbox.checked ? 'true' : 'false');
     }
 
-    // Function to handle 2024 rules toggle
+    // Handles 2024 rules toggle and reloads the page
     function handle2024RulesToggle() {
-        // Store the value in localStorage
         localStorage.setItem('rules2024', rules2024Checkbox.checked ? 'true' : 'false');
-        // Reload the page to load the correct data files
         location.reload();
     }
 
-    // Add event listeners to the checkboxes
-    optionalCheckbox.addEventListener('change', handleRulesToggle);
-    homebrewCheckbox.addEventListener('change', handleRulesToggle);
-    darkModeCheckbox.addEventListener('change', handleDarkModeToggle);
-    rules2024Checkbox.addEventListener('change', handle2024RulesToggle);
-
-    // Call the functions to initially set the correct states
-    handleRulesToggle();
     handleDarkModeToggle();
 
-    // Get the toggle items
     var optionalToggleItem = document.getElementById('optional-toggle-item');
     var homebrewToggleItem = document.getElementById('homebrew-toggle-item');
     var darkModeToggleItem = document.getElementById('darkmode-toggle-item');
     var rules2024ToggleItem = document.getElementById('2024rules-toggle-item');
 
-    // Function to handle click on the toggle items
+    // Helper to toggle checkboxes on click
     function handleToggleClick(checkbox) {
         return function() {
             checkbox.checked = !checkbox.checked;
@@ -197,47 +254,11 @@ document.addEventListener("DOMContentLoaded", function () {
         };
     }
 
-    // Add event listeners to the toggle items
     optionalToggleItem.addEventListener('click', handleToggleClick(optionalCheckbox));
     homebrewToggleItem.addEventListener('click', handleToggleClick(homebrewCheckbox));
     darkModeToggleItem.addEventListener('click', handleToggleClick(darkModeCheckbox));
     rules2024ToggleItem.addEventListener('click', handleToggleClick(rules2024Checkbox));
 
-    // Ensure dark mode is off by default
-    darkModeCheckbox.checked = false;
-    handleDarkModeToggle();
-
-    // Set 2024 rules toggle state from localStorage
-    var rules2024 = localStorage.getItem('rules2024') === 'true';
-    rules2024Checkbox.checked = rules2024;
+    // Ensure correct item visibility on load
+    handleRulesToggle();
 });
-
-// Dynamically load the correct data files based on the 2024 rules toggle
-(function() {
-    var rules2024 = localStorage.getItem('rules2024') === 'true';
-    var head = document.getElementsByTagName('head')[0];
-
-    function loadScript(src) {
-        var script = document.createElement('script');
-        script.src = src;
-        script.defer = false;
-        head.appendChild(script);
-    }
-
-    // Always load movement and other non-action files as usual
-    loadScript('js/data_movement.js');
-    loadScript('js/data_bonusaction.js');
-    loadScript('js/data_reaction.js');
-    loadScript('js/data_condition.js');
-    loadScript('js/data_environment_obscurance.js');
-    loadScript('js/data_environment_light.js');
-    loadScript('js/data_environment_vision.js');
-    loadScript('js/data_environment_cover.js');
-
-    // Load the correct action file
-    if (rules2024) {
-        loadScript('js/2024_data_action.js');
-    } else {
-        loadScript('js/data_action.js');
-    }
-})();


### PR DESCRIPTION
Added 2024  Rules based on https://github.com/nico-713/dnd5e-quickref-2024 repo
Added new feature to save the states of toggles when page is refreshed 
Fixed Modal color in darkmode (Finally 🍾 )

To DO: 
Optional and Homebrew rules are visible on forst load of page, need to add a fix that will only load what is chosen with toggles. Interacting with any toggle for Homebrew/optional fixes this. but switching from 2024 to 2014 introduces the issue again. 
this is minor inconvenience I will address later