### PR TITLE
Add bonus action details for drinking a potion for 2024 rules as standard

### DIFF
--- a/js/2024_data_bonusaction.js
+++ b/js/2024_data_bonusaction.js
@@ -34,5 +34,18 @@ data_bonusaction = [
         bullets: [
 
         ]
-    }
+    },
+    {
+        title: "Drink a potion ",
+        optional: "Standard rule",
+        icon: "potion-ball",
+        subtitle: "Roll for the effect",
+        description: "Roll the dice as per the description of the potion",
+        bullets: [
+            "Using a Potion: Potions are consumable items. Drinking a potion or administering it to another creature requires a Bonus Action.", 
+            "Applying an oil might take longer as specified in its description.",
+            "Once used, a potion takes effect immediately, and it is used up."
+        ],
+    },
+    
 ]


### PR DESCRIPTION
Add bonus action details for drinking a potion for 2024 rules as standard